### PR TITLE
Auto-determine subproject names

### DIFF
--- a/cmake/DependencyManager.cmake
+++ b/cmake/DependencyManager.cmake
@@ -684,7 +684,7 @@ function(__DependencyManager_getProjectName path outVar)
     # Strip comments (ignoring potential issues due to hashes in strings)
     string(REGEX REPLACE "#[^\r\n]*" "" contents "${contents}")
 
-    if ("${contents}" MATCHES "project[ \t\r\n]*\\([ \t\r\n]*([a-zA-Z_0-9-]+)")
+    if ("${contents}" MATCHES "[pP][rR][oO][jJ][eE][cC][tT][ \t\r\n]*\\([ \t\r\n]*([a-zA-Z_0-9-]+)")
         set(projectName "${CMAKE_MATCH_1}")
     else()
         set(projectName "")


### PR DESCRIPTION
This removes the implicit assumption that the name with which a dependency is declared matches the name of the dependency's project as used in their source code (including casing).
Instead, the project name is now parsed from the top-level CMakeLists.txt file and is therefore decoupled from the name given while declaring the dependency.

Fixes #2